### PR TITLE
Fix juypter notebook list parsing, fix #55

### DIFF
--- a/src/jupyterServices/notebook/utils.ts
+++ b/src/jupyterServices/notebook/utils.ts
@@ -55,7 +55,7 @@ function parseNotebookListItem(item: string) {
     if (!item.trim().startsWith('http')) {
         return;
     }
-    let parts = item.split('::').filter(part => part !== '::');
+    let parts = item.split('::').filter(part => part !== '::').map(part => part.trim());
     let url = parts.shift();
     let startupFolder = item.indexOf('::') > 0 ? parts[0].trim() : null;
     let token = '';


### PR DESCRIPTION
Here is the output of a line of `jupyter notebook list` on my computer:

```
http://localhost:8888/ :: /home/daniel
```

the separator is `::` is surrounded by space, so with the current implementation it added the space to the base URL, causing the issue described in #55.
As I am not sure if other versions of Jupyter return `::` without the surrounding spaces, I 
trimmed the output instead of changing the split separator from `::` to ` :: `.