### PR TITLE
Use white background for text/html result

### DIFF
--- a/browser/src/components/Result/index.tsx
+++ b/browser/src/components/Result/index.tsx
@@ -33,7 +33,7 @@ class ResultList extends React.Component<ResultListProps, ResultListState> {
     }
     // If dealing with images, set the background color to white
     let style = {};
-    if (mimetype.startsWith('image')) {
+    if (mimetype.startsWith('image') || mimetype.startsWith('text/html')) {
       style['backgroundColor'] = 'white';
     }
     if (mimetype === 'text/plain') {


### PR DESCRIPTION
* Use white background to increase visibility of the GUI icons on dark UI themes.

Before applying this change:
<img width="330" alt="2017-12-22 23 48 43" src="https://user-images.githubusercontent.com/40454/34302105-d459c76c-e772-11e7-9fc4-135be3677d65.png">

After applying this change:
<img width="333" alt="2017-12-22 23 52 06" src="https://user-images.githubusercontent.com/40454/34302178-26e1b9f4-e773-11e7-9f14-00e167f3fe2e.png">


test code from mpld3 example code
```python
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd
import mpld3
from mpld3 import plugins
mpld3.enable_notebook()
np.random.seed(9615)

# generate df
N = 100
df = pd.DataFrame((.1 * (np.random.random((N, 5)) - .5)).cumsum(0),
                  columns=['a', 'b', 'c', 'd', 'e'],)

# plot line + confidence interval
fig, ax = plt.subplots()
ax.grid(True, alpha=0.3)

for key, val in df.iteritems():
    l, = ax.plot(val.index, val.values, label=key)
    ax.fill_between(val.index,
                    val.values * .5, val.values * 1.5,
                    color=l.get_color(), alpha=.4)

# define interactive legend

handles, labels = ax.get_legend_handles_labels() # return lines and labels
interactive_legend = plugins.InteractiveLegendPlugin(zip(handles,
                                                         ax.collections),
                                                     labels,
                                                     alpha_unsel=0.5,
                                                     alpha_over=1.5,
                                                     start_visible=True)
plugins.connect(fig, interactive_legend)

ax.set_xlabel('x')
ax.set_ylabel('y')
ax.set_title('Interactive legend', size=20)
fig.patch.set_facecolor('blue')
fig.patch.set_alpha(1.0)
mpld3.display()
```