### PR TITLE
Add command to clear results

### DIFF
--- a/browser/src/containers/App/index.tsx
+++ b/browser/src/containers/App/index.tsx
@@ -40,6 +40,9 @@ class App extends React.Component<AppProps, AppState>{
     this.socket.on('clientExists', (data: any) => {
       this.socket.emit('clientExists', { id: data.id });
     });
+    this.socket.on('results.clear', (_data: any) => {
+      this.clearResults();
+    });
     this.socket.on('results', (value: NotebookOutput[]) => {
       if (!this.props.settings.appendResults) {
         this.props.resultActions.clearResults();

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
         "command": "jupyter.selectExistingNotebook",
         "title": "Select an existing (local) Jupyter Notebook",
         "category": "Jupyter"
+      },
+      {
+        "command": "jupyter.clearResults",
+        "title": "Clear Jupyter notebook results",
+        "category": "Jupyter"
       }
     ],
     "menus": {
@@ -124,6 +129,10 @@
         },
         {
           "command": "jupyter.gotToNextCell",
+          "when": "jupyter.document.hasCodeCells"
+        },
+        {
+          "command": "jupyter.clearResults",
           "when": "jupyter.document.hasCodeCells"
         }
       ],

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,6 +12,7 @@ export namespace Commands {
         export const StartKernelForKernelSpeck = 'jupyter.sartKernelForKernelSpecs';
         export const ExecuteRangeInKernel = 'jupyter.execRangeInKernel';
         export const ExecuteSelectionOrLineInKernel = 'jupyter.runSelectionLine';
+        export const ClearResults = 'jupyter.clearResults';
         export namespace Cell {
             export const ExecuteCurrentCell = 'jupyter.execCurrentCell';
             export const ExecuteCurrentCellAndAdvance = 'jupyter.execCurrentCellAndAdvance';

--- a/src/display/main.ts
+++ b/src/display/main.ts
@@ -31,6 +31,9 @@ export class JupyterDisplay extends vscode.Disposable {
         this.disposables.push(vscode.commands.registerCommand(Commands.Jupyter.Kernel_Options, this.showKernelOptions.bind(this)));
         this.previewWindow = new TextDocumentContentProvider();
         this.disposables.push(vscode.workspace.registerTextDocumentContentProvider(jupyterSchema, this.previewWindow));
+        this.disposables.push(vscode.commands.registerCommand(Commands.Jupyter.ClearResults, () => {
+            this.server.clearResults();
+        }));
         this.cellOptions = new CellOptions(cellCodeLenses);
         this.disposables.push(this.cellOptions);
         this.server.on('settings.appendResults', append => {

--- a/src/display/server.ts
+++ b/src/display/server.ts
@@ -100,6 +100,10 @@ export class Server extends EventEmitter {
         this.broadcast('results', results);
     }
 
+    public clearResults() {
+        this.broadcast('results.clear', {});
+    }
+
     public sendVariable(data: any[]) {
         // Add an id to each item (poor separation of concerns... but what ever)
         let results = data.map(item => { return { id: uniqid('x'), value: {'text/plain': JSON.stringify(item) }}; });


### PR DESCRIPTION
Hi and thank you for this plugin.

Although I prefer to append the results, I sometimes want to clear the results pane.
I could not find a way to do this with the keyboard, so I added a `jupyter.clearResults`
command in order to do so.